### PR TITLE
Improve README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,23 +5,28 @@ SparkFun APDS9960 RGB and Gesture Sensor Arduino Library
 
 [*Avago APDS-9960 Breakout Board (SEN-12787)*](https://www.sparkfun.com/products/12787)
 
-Getting Started
----------------
+Library Installation
+--------------------
 
 * Download the Git repository as a ZIP ("Download ZIP" button)
 * Unzip
 * Copy the entire library directory (APDS-9960_RGB_and_Gesture_Sensor_Arduino_Library
-) to \<Arduino installation directory\>/libraries
-* Open the Arduino program
-* Select File -> Examples -> SparkFun_APDS9960 -> GestureTest
-* Plug in your Arduino and APDS-9960 with the following connections
+) to \<Sketchbook directory\>/libraries. You can find the location of your
+\<Sketchbook directory\> at File -> Preferences -> Sketchbook location.
 
 *-OR-*
 
-* Use the library manager
+* [Use the Library Manager](https://learn.sparkfun.com/tutorials/installing-an-arduino-library#using-the-library-manager)
+
+Getting Started
+---------------
+
+* Open the Arduino IDE
+* Select File -> Examples -> SparkFun APDS9960 RGB and Gesture Sensor -> GestureTest
+* Plug in your Arduino and APDS-9960 with the following connections
 
 | Arduino Pin | APDS-9960 Board | Function |
-|---|---|---| 
+|---|---|---|
 | 3.3V | VCC | Power |
 | GND | GND | Ground |
 | A4 | SDA | I2C Data |
@@ -29,7 +34,7 @@ Getting Started
 | 2 | INT | Interrupt |
 
 * Go to Tools -> Board and select your Arduino board
-* Go to Tools -> Serial Port and select the COM port of your Arduino board
+* Go to Tools -> Port and select the COM port of your Arduino board
 * Click "Upload"
 * Go to Tools -> Serial Monitor
 * Ensure the baud rate is set at 9600 baud
@@ -38,9 +43,9 @@ Getting Started
 Repository Contents
 -------------------
 
-* **/examples** - Example sketches for the library (.ino). Run these from the Arduino IDE. 
+* **/examples** - Example sketches for the library (.ino). Run these from the Arduino IDE.
 * **/src** - Source files for the library (.cpp, .h).
-* **library.properties** - General library properties for the Arduino package manager. 
+* **library.properties** - General library properties for the Arduino package manager.
 
 Documentation
 --------------
@@ -49,15 +54,15 @@ Documentation
 * **[Product Repository](https://github.com/sparkfun/APDS-9960_RGB_and_Gesture_Sensor)** - Main repository (including hardware files) for the SparkFun_APDS9960 RGB and Gesture Sensor.
 * **[Hookup Guide](https://learn.sparkfun.com/tutorials/apds-9960-rgb-and-gesture-sensor-hookup-guide)** - Basic hookup guide for the sensor.
 
-Products that use this Library 
+Products that use this Library
 ---------------------------------
 
-* [SEN-12787](https://www.sparkfun.com/products/12787)- Avago APDS-9960 
+* [SEN-12787](https://www.sparkfun.com/products/12787) - Avago APDS-9960
 
 Version History
 ---------------
-* [V_1.4.1](https://github.com/sparkfun/SparkFun_APDS-9960_Sensor_Arduino_Library/tree/V_1.4.1) - Removing blank files, updating library.properties file. 
-* [V_1.4.0](https://github.com/sparkfun/APDS-9960_RGB_and_Gesture_Sensor_Arduino_Library/tree/V_1.4.0) - Updated to new library structure
+* V_1.4.1 - Removing blank files, updating library.properties file.
+* V_1.4.0 - Updated to new library structure
 * V_1.3.0 - Implemented disableProximitySensor(). Thanks to jmg5150 for catching that!
 * V_1.2.0 - Added pinMode line to GestureTest demo to fix interrupt bug with some Arduinos
 * V_1.1.0 - Updated GestureTest demo to not freeze with fast swipes
@@ -71,7 +76,7 @@ Version History
 License Information
 -------------------
 
-This product is _**open source**_! 
+This product is _**open source**_!
 
 The **code** is beerware; if you see me (or any other SparkFun employee) at the local, and you've found our code helpful, please buy us a round!
 


### PR DESCRIPTION
- Split "Getting Started" section into "Library Installation" and "Getting Started". This fixes the previous awkwardness of the two installation options breaking the flow to opening the example.
- Manual installation to sketchbook folder, not to the IDE installation folder. Installing to the IDE installation folder is a bad idea because the library will need to be reinstalled whenever the IDE is updated to a new version.
- Link to SparkFun's instructions for Library Manager installation.
- Use correct menu path to example. The Arduino IDE uses the name value set in library.properties.
- Trim trailing whitespace.
- Fix menu path to Port menu.
- Remove dead release links. I did find the 1.4.1 release here: https://github.com/sparkfun/APDS-9960_RGB_and_Gesture_Sensor/releases/tag/V_H1.0_L1.4.1. I would be happy to add that link to this PR on request.