### PR TITLE
Allow reading status register

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SparkFun APDS9960 RGB and Gesture Sensor
-version=1.4.2
+version=1.4.3
 author=SparkFun Electronics <techsupport@sparkfun.com>
 maintainer=SparkFun Electronics <sparkfun.com>
 sentence=Library for the Avago APDS-9960 sensor

--- a/src/SparkFun_APDS9960.cpp
+++ b/src/SparkFun_APDS9960.cpp
@@ -199,6 +199,23 @@ bool SparkFun_APDS9960::init()
  ******************************************************************************/
 
 /**
+ * @brief Reads and returns the contents of the STATUS register
+ *
+ * @return Contents of the STATUS register. 0xFF if error.
+ */
+uint8_t SparkFun_APDS9960::getStatusRegister()
+{
+    uint8_t status_value;
+
+    /* Read current ENABLE register */
+    if(!wireReadDataByte(APDS9960_STATUS, status_value) ) {
+        return ERROR;
+    }
+
+    return status_value;
+}
+
+/**
  * @brief Reads and returns the contents of the ENABLE register
  *
  * @return Contents of the ENABLE register. 0xFF if error.

--- a/src/SparkFun_APDS9960.h
+++ b/src/SparkFun_APDS9960.h
@@ -98,6 +98,14 @@
 #define APDS9960_GEN            0b01000000
 #define APDS9960_GVALID         0b00000001
 
+/* Status bit fields */
+#define APDS9960_AVALID         0b0000001
+#define APDS9960_PVALID         0b0000010
+#define APDS9960_GINT           0b0000100
+#define APDS9960_AINT           0b0010000
+#define APDS9960_PGSAT          0b0100000
+#define APDS9960_CPSAT          0b1000000
+
 /* On/Off definitions */
 #define OFF                     0
 #define ON                      1

--- a/src/SparkFun_APDS9960.h
+++ b/src/SparkFun_APDS9960.h
@@ -229,6 +229,7 @@ public:
     SparkFun_APDS9960();
     ~SparkFun_APDS9960();
     bool init();
+    uint8_t getStatusRegister();
     uint8_t getMode();
     bool setMode(uint8_t mode, uint8_t enable);
     


### PR DESCRIPTION
Allow reading the status register. This register is important in determining if the value of the ALS and proximity sensor is valid.

Not changing the read functions since I assume there was a reason that the status register was not checked (performance?).