### PR TITLE
attachInterpt to pin actually being used for INT

### DIFF
--- a/examples/AmbientLightInterrupt/AmbientLightInterrupt.ino
+++ b/examples/AmbientLightInterrupt/AmbientLightInterrupt.ino
@@ -73,7 +73,7 @@ void setup() {
   Serial.println(F("-------------------------------------"));
   
   // Initialize interrupt service routine
-  attachInterrupt(0, interruptRoutine, FALLING);
+  attachInterrupt(APDS9960_INT, interruptRoutine, FALLING);
   
   // Initialize APDS-9960 (configure I2C and initial values)
   if ( apds.init() ) {

--- a/examples/GestureTest/GestureTest.ino
+++ b/examples/GestureTest/GestureTest.ino
@@ -70,7 +70,7 @@ void setup() {
   Serial.println(F("--------------------------------"));
   
   // Initialize interrupt service routine
-  attachInterrupt(0, interruptRoutine, FALLING);
+  attachInterrupt(APDS9960_INT, interruptRoutine, FALLING);
 
   // Initialize APDS-9960 (configure I2C and initial values)
   if ( apds.init() ) {
@@ -89,10 +89,10 @@ void setup() {
 
 void loop() {
   if( isr_flag == 1 ) {
-    detachInterrupt(0);
+    detachInterrupt(APDS9960_INT);
     handleGesture();
     isr_flag = 0;
-    attachInterrupt(0, interruptRoutine, FALLING);
+    attachInterrupt(APDS9960_INT, interruptRoutine, FALLING);
   }
 }
 

--- a/examples/ProximityInterrupt/ProximityInterrupt.ino
+++ b/examples/ProximityInterrupt/ProximityInterrupt.ino
@@ -67,7 +67,7 @@ void setup() {
   Serial.println(F("---------------------------------------"));
   
   // Initialize interrupt service routine
-  attachInterrupt(0, interruptRoutine, FALLING);
+  attachInterrupt(APDS9960_INT, interruptRoutine, FALLING);
   
   // Initialize APDS-9960 (configure I2C and initial values)
   if ( apds.init() ) {


### PR DESCRIPTION
Certainly when using an ESP32, the interrupt never fires with the default examples, only if I pass the INT pin to the attach