### PR TITLE
[FEATURE] Support a clone with different device id

### DIFF
--- a/src/SparkFun_APDS9960.cpp
+++ b/src/SparkFun_APDS9960.cpp
@@ -63,7 +63,8 @@ bool SparkFun_APDS9960::init()
     if( !wireReadDataByte(APDS9960_ID, id) ) {
         return false;
     }
-    if( !(id == APDS9960_ID_1 || id == APDS9960_ID_2) ) {
+    if( !(id == APDS9960_ID_1 || id == APDS9960_ID_2) 
+          id == APDS9960_ID_3 ) {
         return false;
     }
      

--- a/src/SparkFun_APDS9960.h
+++ b/src/SparkFun_APDS9960.h
@@ -10,7 +10,7 @@
  * relies on the Arduino Wire (I2C) library. to use the library, instantiate an
  * APDS9960 object, call init(), and call the appropriate functions.
  */
- 
+
 #ifndef SparkFun_APDS9960_H
 #define SparkFun_APDS9960_H
 
@@ -32,7 +32,8 @@
 
 /* Acceptable device IDs */
 #define APDS9960_ID_1           0xAB
-#define APDS9960_ID_2           0x9C 
+#define APDS9960_ID_2           0x9C
+#define APDS9960_ID_3           0xA8
 
 /* Misc parameters */
 #define FIFO_PAUSE_TIME         30      // Wait period (ms) between FIFO reads
@@ -148,7 +149,7 @@
 #define LED_BOOST_100           0
 #define LED_BOOST_150           1
 #define LED_BOOST_200           2
-#define LED_BOOST_300           3    
+#define LED_BOOST_300           3
 
 /* Gesture wait time values */
 #define GWTIME_0MS              0
@@ -166,7 +167,7 @@
 #define DEFAULT_PROX_PPULSE     0x87    // 16us, 8 pulses
 #define DEFAULT_GESTURE_PPULSE  0x89    // 16us, 10 pulses
 #define DEFAULT_POFFSET_UR      0       // 0 offset
-#define DEFAULT_POFFSET_DL      0       // 0 offset      
+#define DEFAULT_POFFSET_DL      0       // 0 offset
 #define DEFAULT_CONFIG1         0x60    // No 12x wait (WTIME) factor
 #define DEFAULT_LDRIVE          LED_DRIVE_100MA
 #define DEFAULT_PGAIN           PGAIN_4X
@@ -176,10 +177,10 @@
 #define DEFAULT_AILT            0xFFFF  // Force interrupt for calibration
 #define DEFAULT_AIHT            0
 #define DEFAULT_PERS            0x11    // 2 consecutive prox or ALS for int.
-#define DEFAULT_CONFIG2         0x01    // No saturation interrupts or LED boost  
+#define DEFAULT_CONFIG2         0x01    // No saturation interrupts or LED boost
 #define DEFAULT_CONFIG3         0       // Enable all photodiodes, no SAI
 #define DEFAULT_GPENTH          40      // Threshold for entering gesture mode
-#define DEFAULT_GEXTH           30      // Threshold for exiting gesture mode    
+#define DEFAULT_GEXTH           30      // Threshold for exiting gesture mode
 #define DEFAULT_GCONF1          0x40    // 4 gesture events for int., 1 for exit
 #define DEFAULT_GGAIN           GGAIN_4X
 #define DEFAULT_GLDRIVE         LED_DRIVE_100MA
@@ -232,11 +233,11 @@ public:
     uint8_t getStatusRegister();
     uint8_t getMode();
     bool setMode(uint8_t mode, uint8_t enable);
-    
+
     /* Turn the APDS-9960 on and off */
     bool enablePower();
     bool disablePower();
-    
+
     /* Enable or disable specific sensors */
     bool enableLightSensor(bool interrupts = false);
     bool disableLightSensor();
@@ -244,13 +245,13 @@ public:
     bool disableProximitySensor();
     bool enableGestureSensor(bool interrupts = true);
     bool disableGestureSensor();
-    
+
     /* LED drive strength control */
     uint8_t getLEDDrive();
     bool setLEDDrive(uint8_t drive);
     uint8_t getGestureLEDDrive();
     bool setGestureLEDDrive(uint8_t drive);
-    
+
     /* Gain control */
     uint8_t getAmbientLightGain();
     bool setAmbientLightGain(uint8_t gain);
@@ -258,19 +259,19 @@ public:
     bool setProximityGain(uint8_t gain);
     uint8_t getGestureGain();
     bool setGestureGain(uint8_t gain);
-    
+
     /* Get and set light interrupt thresholds */
     bool getLightIntLowThreshold(uint16_t &threshold);
     bool setLightIntLowThreshold(uint16_t threshold);
     bool getLightIntHighThreshold(uint16_t &threshold);
     bool setLightIntHighThreshold(uint16_t threshold);
-    
+
     /* Get and set proximity interrupt thresholds */
     bool getProximityIntLowThreshold(uint8_t &threshold);
     bool setProximityIntLowThreshold(uint8_t threshold);
     bool getProximityIntHighThreshold(uint8_t &threshold);
     bool setProximityIntHighThreshold(uint8_t threshold);
-    
+
     /* Get and set interrupt enables */
     uint8_t getAmbientLightIntEnable();
     bool setAmbientLightIntEnable(uint8_t enable);
@@ -278,24 +279,24 @@ public:
     bool setProximityIntEnable(uint8_t enable);
     uint8_t getGestureIntEnable();
     bool setGestureIntEnable(uint8_t enable);
-    
+
     /* Clear interrupts */
     bool clearAmbientLightInt();
     bool clearProximityInt();
-    
+
     /* Ambient light methods */
     bool readAmbientLight(uint16_t &val);
     bool readRedLight(uint16_t &val);
     bool readGreenLight(uint16_t &val);
     bool readBlueLight(uint16_t &val);
-    
+
     /* Proximity methods */
     bool readProximity(uint8_t &val);
-    
+
     /* Gesture methods */
     bool isGestureAvailable();
     int readGesture();
-    
+
 private:
 
     /* Gesture processing */
@@ -308,27 +309,27 @@ private:
     bool setProxIntLowThresh(uint8_t threshold);
     uint8_t getProxIntHighThresh();
     bool setProxIntHighThresh(uint8_t threshold);
-    
+
     /* LED Boost Control */
     uint8_t getLEDBoost();
     bool setLEDBoost(uint8_t boost);
-    
+
     /* Proximity photodiode select */
     uint8_t getProxGainCompEnable();
     bool setProxGainCompEnable(uint8_t enable);
     uint8_t getProxPhotoMask();
     bool setProxPhotoMask(uint8_t mask);
-    
+
     /* Gesture threshold control */
     uint8_t getGestureEnterThresh();
     bool setGestureEnterThresh(uint8_t threshold);
     uint8_t getGestureExitThresh();
     bool setGestureExitThresh(uint8_t threshold);
-    
+
     /* Gesture LED, gain, and time control */
     uint8_t getGestureWaitTime();
     bool setGestureWaitTime(uint8_t time);
-    
+
     /* Gesture mode */
     uint8_t getGestureMode();
     bool setGestureMode(uint8_t mode);


### PR DESCRIPTION
Add support for a clone of the APDS9960 with a different device id (0xA8) which otherwise cannot be initialized.

Apparently there are clones of the APDS9960 that use a different device ID than the original. For these, the initialisation then fails.

SparkFun_APDS-9960.h:
Addition of the new ID

SparkFun_APDS-9960.cpp:
Extension of the if-condition in the class `sparkFun_APDS9960::init()` to take the new ID into account during initialisation.

The changes to the code are minimal and should not create any further side effects.