### PR TITLE
Added cheap chinese clone ID as valid device

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SparkFun APDS9960 RGB and Gesture Sensor
-version=1.4.3
+version=1.4.4
 author=SparkFun Electronics <techsupport@sparkfun.com>
 maintainer=SparkFun Electronics <sparkfun.com>
 sentence=Library for the Avago APDS-9960 sensor

--- a/src/SparkFun_APDS9960.cpp
+++ b/src/SparkFun_APDS9960.cpp
@@ -63,7 +63,7 @@ bool SparkFun_APDS9960::init()
     if( !wireReadDataByte(APDS9960_ID, id) ) {
         return false;
     }
-    if( !(id == APDS9960_ID_1 || id == APDS9960_ID_2) ) {
+    if( !(id == APDS9960_ID_1 || id == APDS9960_ID_2 || id == APDS9960_ID_3) ) {
         return false;
     }
      

--- a/src/SparkFun_APDS9960.h
+++ b/src/SparkFun_APDS9960.h
@@ -33,6 +33,7 @@
 /* Acceptable device IDs */
 #define APDS9960_ID_1           0xAB
 #define APDS9960_ID_2           0x9C 
+#define APDS9960_ID_3           0xA8 // cheap chinese clone of APDS9660 -> Can only handle gains with factor 1x!
 
 /* Misc parameters */
 #define FIFO_PAUSE_TIME         30      // Wait period (ms) between FIFO reads


### PR DESCRIPTION
There are clones on the market of the APDS9660 with a different ID then the originals.
Second pull request for this ID.
Please approve.